### PR TITLE
Fix Google Analytics ID

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -16,13 +16,8 @@ const config: GatsbyConfig = {
       resolve: "gatsby-plugin-google-gtag",
       options: {
         trackingIds: ["G-M4KQQPNPGB",],
-        gtagConfig: {
-          anonymize_ip: true,
-          cookie_expires: 0,
-        },
         pluginConfig: {
           head: false,
-          respectDNT: true,
         },
       },
     },


### PR DESCRIPTION
Turns out the ID was correct, some of the other options aren't in the Google Analytics instructions so I removed them