### PR TITLE
Use optimized Google Fonts plugin

### DIFF
--- a/gatsby-browser.ts
+++ b/gatsby-browser.ts
@@ -1,2 +1,3 @@
 import "bootstrap/dist/css/bootstrap.min.css"
+import "@fontsource/roboto-slab"
 import "./src/styles/global.css"

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -34,16 +34,6 @@ const config: GatsbyConfig = {
         icon: "src/images/HockeyRATS_Icon.png",
       },
     },
-    {
-      resolve: `gatsby-plugin-google-fonts`,
-      options: {
-        fonts: [
-          `Roboto Slab\:400,700`,
-          `sans-serif`
-        ],
-        display: `swap`
-      }
-    },
     "gatsby-plugin-image",
     "gatsby-plugin-sharp",
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "bootstrap": "^5.2.3",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^4.2.1",
-        "gatsby-plugin-google-fonts": "^1.0.1",
         "gatsby-plugin-image": "^3.9.0",
         "gatsby-plugin-sharp": "^5.9.0",
         "gatsby-source-filesystem": "^5.9.0",
@@ -8782,12 +8781,6 @@
       "peerDependencies": {
         "@parcel/core": "^2.0.0"
       }
-    },
-    "node_modules/gatsby-plugin-google-fonts": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-fonts/-/gatsby-plugin-google-fonts-1.0.1.tgz",
-      "integrity": "sha512-p1NVkn27GUnDA5qHM+Z4cCcLCJIardzZXMon3640sT4xuL/AZJbsx3HEt2KY/5oZu0UXIkytkxzV2Da4rQeUIg==",
-      "dev": true
     },
     "node_modules/gatsby-plugin-google-gtag": {
       "version": "5.8.0",
@@ -22406,12 +22399,6 @@
         "@parcel/transformer-js": "2.8.3",
         "@parcel/transformer-json": "2.8.3"
       }
-    },
-    "gatsby-plugin-google-fonts": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-fonts/-/gatsby-plugin-google-fonts-1.0.1.tgz",
-      "integrity": "sha512-p1NVkn27GUnDA5qHM+Z4cCcLCJIardzZXMon3640sT4xuL/AZJbsx3HEt2KY/5oZu0UXIkytkxzV2Da4rQeUIg==",
-      "dev": true
     },
     "gatsby-plugin-google-gtag": {
       "version": "5.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
+        "@fontsource/roboto-slab": "^4.5.11",
         "@types/node": "^18.15.11",
         "@types/react": "^18.0.33",
         "@types/react-dom": "^18.0.11",
@@ -2018,6 +2019,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/@fontsource/roboto-slab": {
+      "version": "4.5.11",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto-slab/-/roboto-slab-4.5.11.tgz",
+      "integrity": "sha512-0HXK8WNvZZg4vglhUY4ySBmlh+wnO1JsGcPfCaxDhY24gtRf2POmmeNpSxKFjjQTDV8BiYDXF2H9p15d/6c/YA==",
+      "dev": true
     },
     "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd": {
       "version": "2.8.0",
@@ -17330,6 +17337,12 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
+    },
+    "@fontsource/roboto-slab": {
+      "version": "4.5.11",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto-slab/-/roboto-slab-4.5.11.tgz",
+      "integrity": "sha512-0HXK8WNvZZg4vglhUY4ySBmlh+wnO1JsGcPfCaxDhY24gtRf2POmmeNpSxKFjjQTDV8BiYDXF2H9p15d/6c/YA==",
+      "dev": true
     },
     "@gatsbyjs/parcel-namer-relative-to-cwd": {
       "version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@fontsource/roboto-slab": "^4.5.11",
     "@types/node": "^18.15.11",
     "@types/react": "^18.0.33",
     "@types/react-dom": "^18.0.11",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "bootstrap": "^5.2.3",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "gatsby-plugin-google-fonts": "^1.0.1",
     "gatsby-plugin-image": "^3.9.0",
     "gatsby-plugin-sharp": "^5.9.0",
     "gatsby-source-filesystem": "^5.9.0",


### PR DESCRIPTION
Uninstalled gatsby-plugin-google-fonts and installed @fontsource/roboto-slab

Followed guide at https://www.gatsbyjs.com/docs/how-to/styling/using-web-fonts/#self-host-google-fonts-with-fontsource